### PR TITLE
functions: check if 'which' actually works

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -309,6 +309,10 @@ you must use a VT2 terminal as directed per https://mrchromebox.tech/#fwscript"
 		|| die "This script only supports 64-bit OS on x86_64-based devices; ARM devices are not supported."
 	
 	#check for required tools
+	if ! command -v which > /dev/null 2>&1; then
+		echo_red "Required package 'which' not found; cannot continue.  Please install and try again."
+		return 1
+	fi
 	if ! which dmidecode > /dev/null 2>&1; then
 		echo_red "Required package 'dmidecode' not found; cannot continue.  Please install and try again."
 		return 1


### PR DESCRIPTION
Currently, the functions script does not validate whether the "which" command is actually present. Due to this, the script blindly tries using it to detect where dmidecode is, which leads to confusing error messages like 
```Required package 'dmidecode' not found; cannot continue.  Please install and try again.```
 despite dmidecode being fully functional and working. Most distributions have this installed by default, but ones like Arch do not, so it is important that we check if this works before using it. Since which obviously will not work to check itself in this case, a compromise is to just check if it runs without errors with "command -v", which has been supported by Bash for a very long time.

While not confirmed, this issue was likely the root cause of #220.